### PR TITLE
fix blinkproblem for all 4 tasks

### DIFF
--- a/U_Taskmanegement/main.c
+++ b/U_Taskmanegement/main.c
@@ -206,7 +206,7 @@ void vLedPairOne( void *pvParameters )
 	
 	for(;;)
 	{
-		PORTF.OUTTGL = 0x00;				//Changed this value from 0x03 to 0x00
+		PORTF.OUTTGL = 0x03;				//Changed this value from 0x03 to 0x00
 		vTaskDelay(100 / portTICK_RATE_MS);
 	}
 }
@@ -214,11 +214,11 @@ void vLedPairOne( void *pvParameters )
 void vLedPairTwo( void *pvParameters )
 {
 	PORTF.DIRSET = (1 << 3) | (1 << 2) ; /*LED4 & LED3*/
-	PORTF.OUTCLR = 0x0F;
+	PORTF.OUTCLR = 0x0C;
 		
 	for(;;)
 	{
-		PORTF.OUTTGL |= 0x0F;
+		PORTF.OUTTGL = 0x0C;
 		vTaskDelay(100 / portTICK_RATE_MS);		
 	}
 }
@@ -226,11 +226,11 @@ void vLedPairTwo( void *pvParameters )
 void vLedPairThree( void *pvParameters )
 {
 	PORTE.DIRSET = (1 << 1) | (1 << 0); /*LED5 & LED6*/
-	PORTE.OUTCLR = 0x0F;
+	PORTE.OUTCLR = 0x03;
 	
 	for(;;)
 	{
-		PORTE.OUTTGL = 0x00;						// Changed this value from 0x03 to 0x00
+		PORTE.OUTTGL = 0x03;						// Changed this value from 0x03 to 0x00
 		vTaskDelay(100 / portTICK_RATE_MS);
 	}
 }
@@ -242,7 +242,7 @@ void vLedPairFour( void *pvParameters )
 	
 	for(;;)
 	{
-		PORTE.OUTTGL |= 0x0C;
+		PORTE.OUTTGL = 0x0C;
 		vTaskDelay(100 / portTICK_RATE_MS);
 	}
 }


### PR DESCRIPTION
Ich hab das mal so gefixt, dass es bei mir läuft. (Bei mir blinken jetzt alle LED's)
Was mir aufgefallen ist, ist dass du an einigen Orten immer noch das "PORTE.OUTTGL |= 0x03;" verwendest.
Das Problem mit diesen OUTTGL und OUTSET und OUTCLR (Und auch DIRSET) Registern ist, dass sie nicht echte Register sind. Das sind eine Art virtuelle Register, welche für spezielle funktionsweisen gedacht sind. 
Diese Virtuellen Register setzen sich automatisch zurück und sollten meines Wissens nach nur mit "=" beschrieben werden. Ansonsten passieren eben komische Sachen.
Versuchs mal mit dem Pull-Request. Bin gespannt obs so dann läuft.